### PR TITLE
Implement enums and JWT security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/orm": "^3.3",
         "nelmio/cors-bundle": "^2.5",
+        "lexik/jwt-authentication-bundle": "^2.20",
         "phpdocumentor/reflection-docblock": "^5.6",
         "phpstan/phpdoc-parser": "^2.1",
         "symfony/asset": "7.3.*",

--- a/config/packages/lexik_jwt_authentication.yaml
+++ b/config/packages/lexik_jwt_authentication.yaml
@@ -1,0 +1,5 @@
+lexik_jwt_authentication:
+    secret_key: '%kernel.project_dir%/config/jwt/private.pem'
+    public_key: '%kernel.project_dir%/config/jwt/public.pem'
+    pass_phrase: ''
+    token_ttl: 3600

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,14 +4,19 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
+            stateless: true
+            jwt: ~
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
@@ -22,8 +27,8 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/api/login, roles: PUBLIC_ACCESS }
+        - { path: ^/api, roles: ROLE_USER }
 
 when@test:
     security:

--- a/config/packages/validator.yaml
+++ b/config/packages/validator.yaml
@@ -1,9 +1,7 @@
 framework:
     validation:
-        # Enables validator auto-mapping support.
-        # For instance, basic validation constraints will be inferred from Doctrine's metadata.
-        #auto_mapping:
-        #    App\Entity\: []
+        auto_mapping:
+            App\Entity\: []
 
 when@test:
     framework:

--- a/config/routes/lexik_jwt.yaml
+++ b/config/routes/lexik_jwt.yaml
@@ -1,0 +1,4 @@
+login:
+    path: /api/login
+    methods: [POST]
+    controller: lexik_jwt_authentication.controller.login

--- a/src/Controller/TicketController.php
+++ b/src/Controller/TicketController.php
@@ -4,6 +4,7 @@
 namespace App\Controller;
 
 use App\Entity\Ticket;
+use App\Enum\TicketPriority;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -30,7 +31,12 @@ class TicketController extends AbstractController
         $ticket = new Ticket();
         $ticket->setTitle($data['title']);
         $ticket->setDescription($data['description']);
-        $ticket->setPriority($data['priority']);
+
+        try {
+            $ticket->setPriority(TicketPriority::from($data['priority']));
+        } catch (\ValueError $e) {
+            return $this->json(['error' => 'Invalid priority'], 400);
+        }
         $ticket->setOwner($security->getUser());
 
         $errors = $validator->validate($ticket);

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -5,7 +5,23 @@ namespace App\Entity;
 use App\Repository\CommentRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Delete;
 
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+        new Post(security: "is_granted('ROLE_USER')"),
+        new Put(security: "is_granted('ROLE_USER')"),
+        new Delete(security: "is_granted('ROLE_USER')")
+    ]
+)]
 #[ORM\Entity(repositoryClass: CommentRepository::class)]
 class Comment
 {
@@ -15,6 +31,7 @@ class Comment
     private ?int $id = null;
 
     #[ORM\Column(type: Types::TEXT)]
+    #[Assert\NotBlank]
     private ?string $content = null;
 
     #[ORM\Column]
@@ -22,11 +39,18 @@ class Comment
 
     #[ORM\ManyToOne(inversedBy: 'comments')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Assert\NotNull]
     private ?User $author = null;
 
     #[ORM\ManyToOne(inversedBy: 'comments')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Assert\NotNull]
     private ?Ticket $ticket = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
 
     public function getId(): ?int
     {

--- a/src/Entity/Ticket.php
+++ b/src/Entity/Ticket.php
@@ -2,12 +2,29 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use App\Enum\TicketPriority;
+use App\Enum\TicketStatus;
 use App\Repository\TicketRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+        new Post(security: "is_granted('ROLE_USER')"),
+        new Put(security: "is_granted('ROLE_USER')"),
+        new Delete(security: "is_granted('ROLE_USER')")
+    ]
+)]
 #[ORM\Entity(repositoryClass: TicketRepository::class)]
 class Ticket
 {
@@ -17,22 +34,25 @@ class Ticket
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT)]
+    #[Assert\NotBlank]
     private ?string $description = null;
 
-    #[ORM\Column(length: 20)]
-    private ?string $priority = null;
+    #[ORM\Column(enumType: TicketPriority::class)]
+    private ?TicketPriority $priority = null;
 
-    #[ORM\Column(length: 20)]
-    private ?string $status = null;
+    #[ORM\Column(enumType: TicketStatus::class)]
+    private ?TicketStatus $status = null;
 
     #[ORM\Column]
     private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\ManyToOne(inversedBy: 'tickets')]
     #[ORM\JoinColumn(nullable: false)]
+    #[Assert\NotNull]
     private ?User $owner = null;
 
     #[ORM\ManyToOne(inversedBy: 'assignedTickets')]
@@ -54,7 +74,7 @@ class Ticket
     {
         $this->comments = new ArrayCollection();
         $this->createdAt = new \DateTimeImmutable();
-        $this->status = 'pending';
+        $this->status = TicketStatus::PENDING;
     }
 
     public function getId(): ?int
@@ -86,24 +106,24 @@ class Ticket
         return $this;
     }
 
-    public function getPriority(): ?string
+    public function getPriority(): ?TicketPriority
     {
         return $this->priority;
     }
 
-    public function setPriority(string $priority): static
+    public function setPriority(TicketPriority $priority): static
     {
         $this->priority = $priority;
 
         return $this;
     }
 
-    public function getStatus(): ?string
+    public function getStatus(): ?TicketStatus
     {
         return $this->status;
     }
 
-    public function setStatus(string $status): static
+    public function setStatus(TicketStatus $status): static
     {
         $this->status = $status;
 
@@ -142,6 +162,17 @@ class Ticket
     public function setAssignee(?User $assignee): static
     {
         $this->assignee = $assignee;
+
+        if (null !== $assignee) {
+            $now = new \DateTimeImmutable();
+            $this->assignedAtLast = $now;
+            if (null === $this->assignedAtFirst) {
+                $this->assignedAtFirst = $now;
+            }
+            if ($this->status === TicketStatus::PENDING) {
+                $this->status = TicketStatus::WAITING;
+            }
+        }
 
         return $this;
     }
@@ -203,5 +234,10 @@ class Ticket
     public function getAssignedTo(): ?User
     {
         return $this->assignee;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->title;
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -6,10 +6,12 @@ use App\Repository\UserRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: '`user`')]
-class User
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Enum/TicketPriority.php
+++ b/src/Enum/TicketPriority.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Enum;
+
+enum TicketPriority: string
+{
+    case LOW = 'basse';
+    case NORMAL = 'normale';
+    case HIGH = 'haute';
+}

--- a/src/Enum/TicketStatus.php
+++ b/src/Enum/TicketStatus.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Enum;
+
+enum TicketStatus: string
+{
+    case PENDING = 'pending';
+    case WAITING = 'waiting';
+    case IN_PROGRESS = 'in_progress';
+    case DONE = 'done';
+}

--- a/src/Security/CommentVoter.php
+++ b/src/Security/CommentVoter.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Security;
+
+use App\Entity\Comment;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class CommentVoter extends Voter
+{
+    public const DELETE = 'COMMENT_DELETE';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return $attribute === self::DELETE && $subject instanceof Comment;
+    }
+
+    /**
+     * @param Comment $subject
+     */
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        return $subject->getAuthor() === $user;
+    }
+}

--- a/src/Security/TicketVoter.php
+++ b/src/Security/TicketVoter.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Security;
+
+use App\Entity\Ticket;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class TicketVoter extends Voter
+{
+    public const EDIT = 'TICKET_EDIT';
+    public const DELETE = 'TICKET_DELETE';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [self::EDIT, self::DELETE]) && $subject instanceof Ticket;
+    }
+
+    /**
+     * @param Ticket $subject
+     */
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        return $subject->getOwner() === $user;
+    }
+}


### PR DESCRIPTION
## Summary
- define `TicketPriority` and `TicketStatus` enums
- enforce enum use in `Ticket` entity and add `__toString`
- auto-set assignment dates and status when assigning tickets
- add validation constraints
- expose `Ticket` and `Comment` as ApiResource
- configure JWT security and add simple voters
- adjust controller and tests

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ffaaf75fc832d9b3812827b1e251d