### PR TITLE
Implement ticket workflow endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ php bin/console doctrine:schema:validate
 
 ### Ce qu’il reste à faire
 
-* Implémenter la logique d’assignation/désassignation via des endpoints dédiés
-* Ajouter la gestion de l’avancement des tickets (start progress/close)
-* Couvrir ces nouvelles routes par des tests et une documentation Swagger
+* Implémenter la logique d’assignation/désassignation via des endpoints dédiés **(fait)**
+* Ajouter la gestion de l’avancement des tickets (start progress/close) **(fait)**
+* Couvrir ces nouvelles routes par des tests et une documentation Swagger *(en cours)*
 * Mettre en place une pipeline CI/CD pour automatiser tests et déploiement
 * Optionnel : notifications email et tableau de bord statistiques
 

--- a/src/Controller/TicketWorkflowController.php
+++ b/src/Controller/TicketWorkflowController.php
@@ -1,0 +1,128 @@
+<?php
+namespace App\Controller;
+
+use App\Entity\Ticket;
+use App\Entity\User;
+use App\Enum\TicketStatus;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class TicketWorkflowController extends AbstractController
+{
+    #[Route('/api/tickets/{id}/assign', name: 'ticket_assign', methods: ['POST'])]
+    public function assign(int $id, Request $request, EntityManagerInterface $em, Security $security): JsonResponse
+    {
+        $ticket = $em->getRepository(Ticket::class)->find($id);
+        if (!$ticket) {
+            return $this->json(['error' => 'Ticket not found'], 404);
+        }
+
+        if ($ticket->getOwner() !== $security->getUser()) {
+            return $this->json(['error' => 'Access denied'], 403);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['assignee_id'])) {
+            return $this->json(['error' => 'Missing assignee_id'], 400);
+        }
+
+        /** @var User|null $user */
+        $user = $em->getRepository(User::class)->find($data['assignee_id']);
+        if (!$user) {
+            return $this->json(['error' => 'Assignee not found'], 404);
+        }
+
+        $ticket->setAssignee($user);
+        $em->flush();
+
+        return $this->json(['message' => 'Ticket assigned']);
+    }
+
+    #[Route('/api/tickets/{id}/unassign', name: 'ticket_unassign', methods: ['POST'])]
+    public function unassign(int $id, EntityManagerInterface $em, Security $security): JsonResponse
+    {
+        $ticket = $em->getRepository(Ticket::class)->find($id);
+        if (!$ticket) {
+            return $this->json(['error' => 'Ticket not found'], 404);
+        }
+
+        if ($ticket->getOwner() !== $security->getUser()) {
+            return $this->json(['error' => 'Access denied'], 403);
+        }
+
+        $ticket->setAssignee(null);
+        $em->flush();
+
+        return $this->json(['message' => 'Ticket unassigned']);
+    }
+
+    #[Route('/api/tickets/{id}/start', name: 'ticket_start', methods: ['POST'])]
+    public function start(int $id, EntityManagerInterface $em, Security $security): JsonResponse
+    {
+        $ticket = $em->getRepository(Ticket::class)->find($id);
+        if (!$ticket) {
+            return $this->json(['error' => 'Ticket not found'], 404);
+        }
+
+        if ($ticket->getAssignee() !== $security->getUser()) {
+            return $this->json(['error' => 'Access denied'], 403);
+        }
+
+        $ticket->setStatus(TicketStatus::IN_PROGRESS);
+        $em->flush();
+
+        return $this->json(['message' => 'Ticket started']);
+    }
+
+    #[Route('/api/tickets/{id}/close', name: 'ticket_close', methods: ['POST'])]
+    public function close(int $id, EntityManagerInterface $em, Security $security): JsonResponse
+    {
+        $ticket = $em->getRepository(Ticket::class)->find($id);
+        if (!$ticket) {
+            return $this->json(['error' => 'Ticket not found'], 404);
+        }
+
+        if ($ticket->getAssignee() !== $security->getUser()) {
+            return $this->json(['error' => 'Access denied'], 403);
+        }
+
+        $ticket->setStatus(TicketStatus::DONE);
+        $em->flush();
+
+        return $this->json(['message' => 'Ticket closed']);
+    }
+
+    #[Route('/api/my-tickets', name: 'my_tickets', methods: ['GET'])]
+    public function myTickets(EntityManagerInterface $em, Security $security): JsonResponse
+    {
+        $tickets = $em->getRepository(Ticket::class)->findBy(['owner' => $security->getUser()]);
+        return $this->json($tickets);
+    }
+
+    #[Route('/api/assigned-tickets', name: 'assigned_tickets', methods: ['GET'])]
+    public function assignedTickets(EntityManagerInterface $em, Security $security): JsonResponse
+    {
+        $tickets = $em->getRepository(Ticket::class)->findBy(['assignee' => $security->getUser()]);
+        return $this->json($tickets);
+    }
+
+    #[Route('/api/me', name: 'current_user', methods: ['GET'])]
+    public function me(Security $security): JsonResponse
+    {
+        /** @var User $user */
+        $user = $security->getUser();
+        if (!$user) {
+            return $this->json(['error' => 'Unauthorized'], 401);
+        }
+
+        return $this->json([
+            'id' => $user->getId(),
+            'email' => $user->getEmail(),
+            'name' => $user->getName(),
+        ]);
+    }
+}

--- a/tests/Controller/TicketWorkflowControllerTest.php
+++ b/tests/Controller/TicketWorkflowControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace App\Tests\Controller;
+
+use App\Entity\Ticket;
+use App\Entity\User;
+use App\Enum\TicketPriority;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TicketWorkflowControllerTest extends WebTestCase
+{
+    private function createUser(): User
+    {
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $user = new User();
+        $user->setEmail(uniqid().'@test.com');
+        $user->setPassword('hash');
+        $user->setName('User');
+        $em->persist($user);
+        $em->flush();
+        return $user;
+    }
+
+    private function createTicket(User $owner): Ticket
+    {
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $ticket = new Ticket();
+        $ticket->setTitle('test');
+        $ticket->setDescription('desc');
+        $ticket->setPriority(TicketPriority::NORMAL);
+        $ticket->setOwner($owner);
+        $em->persist($ticket);
+        $em->flush();
+        return $ticket;
+    }
+
+    public function testAssignTicket(): void
+    {
+        $client = static::createClient();
+        $owner = $this->createUser();
+        $assignee = $this->createUser();
+        $ticket = $this->createTicket($owner);
+
+        $client->loginUser($owner);
+        $client->request('POST', '/api/tickets/'.$ticket->getId().'/assign', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['assignee_id' => $assignee->getId()]));
+        $this->assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary
- add TicketWorkflowController with assign, unassign, start and close routes
- add minimal functional test for assignment
- mark completed tasks in README

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68401f9c8f50832d81fa1d0e349caecb