### PR TITLE
Configure SQLite for tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 use Symfony\Component\Dotenv\Dotenv;
+use App\Kernel;
+use Doctrine\ORM\Tools\SchemaTool;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
@@ -11,3 +13,14 @@ if (method_exists(Dotenv::class, 'bootEnv')) {
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 }
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) ($_SERVER['APP_DEBUG'] ?? false));
+$kernel->boot();
+$entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+$metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+$schemaTool = new SchemaTool($entityManager);
+$schemaTool->dropDatabase();
+if (!empty($metadata)) {
+    $schemaTool->createSchema($metadata);
+}
+$kernel->shutdown();


### PR DESCRIPTION
## Summary
- add SQLite DATABASE_URL in `.env.test`
- initialize database schema automatically in `tests/bootstrap.php`

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684031e94308832d90051d43c4db4151