### PR TITLE
Remove unused getAssignedTo method

### DIFF
--- a/src/Entity/Ticket.php
+++ b/src/Entity/Ticket.php
@@ -234,10 +234,6 @@ class Ticket
         return $this;
     }
 
-    public function getAssignedTo(): ?User
-    {
-        return $this->assignee;
-    }
 
     public function __toString(): string
     {

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -48,11 +48,11 @@ class UserTest extends TestCase
         $user->addAssignedTicket($ticket);
         $this->assertCount(1, $user->getAssignedTickets());
         $this->assertTrue($user->getAssignedTickets()->contains($ticket));
-        $this->assertSame($user, $ticket->getAssignedTo());
+        $this->assertSame($user, $ticket->getAssignee());
 
         $user->removeAssignedTicket($ticket);
         $this->assertCount(0, $user->getAssignedTickets());
-        $this->assertNull($ticket->getAssignedTo());
+        $this->assertNull($ticket->getAssignee());
     }
 
     public function testUsernameIsEmail(): void


### PR DESCRIPTION
## Summary
- drop `getAssignedTo` method
- align tests to use `getAssignee`

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684031e094d4832db1d44f9600ad4893