### PR TITLE
Expose workflow endpoints in API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,4 +221,100 @@ php bin/console doctrine:schema:validate
 
 ---
 
+## 11. 🚀 Exemples d'appels Workflow
+
+### `POST /api/tickets/{id}/assign`
+
+```bash
+curl -X POST http://localhost/api/tickets/1/assign \
+     -H "Authorization: Bearer <JWT>" \
+     -H "Content-Type: application/json" \
+     -d '{"assignee_id": 2}'
+```
+
+Réponse :
+
+```json
+{"message": "Ticket assigned"}
+```
+
+### `POST /api/tickets/{id}/unassign`
+
+```bash
+curl -X POST http://localhost/api/tickets/1/unassign \
+     -H "Authorization: Bearer <JWT>"
+```
+
+Réponse :
+
+```json
+{"message": "Ticket unassigned"}
+```
+
+### `POST /api/tickets/{id}/start`
+
+```bash
+curl -X POST http://localhost/api/tickets/1/start \
+     -H "Authorization: Bearer <JWT>"
+```
+
+Réponse :
+
+```json
+{"message": "Ticket started"}
+```
+
+### `POST /api/tickets/{id}/close`
+
+```bash
+curl -X POST http://localhost/api/tickets/1/close \
+     -H "Authorization: Bearer <JWT>"
+```
+
+Réponse :
+
+```json
+{"message": "Ticket closed"}
+```
+
+### `GET /api/my-tickets`
+
+```bash
+curl -H "Authorization: Bearer <JWT>" http://localhost/api/my-tickets
+```
+
+Réponse (exemple) :
+
+```json
+[
+  {"id": 1, "title": "Bug", "status": "pending"}
+]
+```
+
+### `GET /api/assigned-tickets`
+
+```bash
+curl -H "Authorization: Bearer <JWT>" http://localhost/api/assigned-tickets
+```
+
+Réponse (exemple) :
+
+```json
+[
+  {"id": 1, "title": "Bug", "status": "in_progress"}
+]
+```
+
+### `GET /api/me`
+
+```bash
+curl -H "Authorization: Bearer <JWT>" http://localhost/api/me
+```
+
+Réponse :
+
+```json
+{"id": 1, "email": "user@example.com", "name": "John Doe"}
+```
+
 **Fin de documentation**

--- a/src/Entity/Ticket.php
+++ b/src/Entity/Ticket.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
+use App\Controller\TicketWorkflowController;
 use App\Enum\TicketPriority;
 use App\Enum\TicketStatus;
 use App\Repository\TicketRepository;
@@ -22,7 +23,75 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Get(),
         new GetCollection(),
         new Put(security: "is_granted('ROLE_USER')"),
-        new Delete(security: "is_granted('ROLE_USER')")
+        new Delete(security: "is_granted('ROLE_USER')"),
+        new Post(
+            uriTemplate: '/tickets/{id}/assign',
+            controller: [TicketWorkflowController::class, 'assign'],
+            openapiContext: [
+                'summary' => 'Assign a ticket to a user',
+                'requestBody' => [
+                    'content' => [
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'assignee_id' => ['type' => 'integer']
+                                ],
+                                'required' => ['assignee_id']
+                            ],
+                            'example' => ['assignee_id' => 1]
+                        ]
+                    ]
+                ],
+                'responses' => [
+                    '200' => ['description' => 'Ticket assigned']
+                ]
+            ]
+        ),
+        new Post(
+            uriTemplate: '/tickets/{id}/unassign',
+            controller: [TicketWorkflowController::class, 'unassign'],
+            openapiContext: [
+                'summary' => 'Unassign a ticket',
+                'responses' => [
+                    '200' => ['description' => 'Ticket unassigned']
+                ]
+            ]
+        ),
+        new Post(
+            uriTemplate: '/tickets/{id}/start',
+            controller: [TicketWorkflowController::class, 'start'],
+            openapiContext: [
+                'summary' => 'Start progress on a ticket',
+                'responses' => [
+                    '200' => ['description' => 'Ticket started']
+                ]
+            ]
+        ),
+        new Post(
+            uriTemplate: '/tickets/{id}/close',
+            controller: [TicketWorkflowController::class, 'close'],
+            openapiContext: [
+                'summary' => 'Close a ticket',
+                'responses' => [
+                    '200' => ['description' => 'Ticket closed']
+                ]
+            ]
+        ),
+        new GetCollection(
+            uriTemplate: '/my-tickets',
+            controller: [TicketWorkflowController::class, 'myTickets'],
+            openapiContext: [
+                'summary' => 'List tickets owned by current user'
+            ]
+        ),
+        new GetCollection(
+            uriTemplate: '/assigned-tickets',
+            controller: [TicketWorkflowController::class, 'assignedTickets'],
+            openapiContext: [
+                'summary' => 'List tickets assigned to current user'
+            ]
+        )
     ]
 )]
 #[ORM\Entity(repositoryClass: TicketRepository::class)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -2,7 +2,10 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
 use App\Repository\UserRepository;
+use App\Controller\TicketWorkflowController;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -11,6 +14,19 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: '`user`')]
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/me',
+            controller: [TicketWorkflowController::class, 'me'],
+            read: false,
+            name: 'current_user',
+            openapiContext: [
+                'summary' => 'Get current authenticated user'
+            ]
+        )
+    ]
+)]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]


### PR DESCRIPTION
## Summary
- document workflow routes with examples
- expose workflow routes in Ticket entity via API Platform
- add `/api/me` endpoint in API docs

## Testing
- `php bin/phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684031cbaa90832daf1a39af08a124fe