### PR TITLE
Add GitHub CI workflow for PHPUnit

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
+DATABASE_URL='postgresql://app:password@127.0.0.1:5432/app?serverVersion=16&charset=utf8'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: app_test
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U app -d app_test" --health-interval=10s --health-timeout=5s --health-retries=5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, pdo_pgsql
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Wait for PostgreSQL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+          until pg_isready -h localhost -p 5432 -U app; do
+            sleep 1
+          done
+
+      - name: Create database
+        run: php bin/console doctrine:database:create --env=test --if-not-exists
+
+      - name: Run migrations
+        run: php bin/console doctrine:migrations:migrate --env=test --no-interaction
+
+      - name: Run PHPUnit
+        run: php bin/phpunit
+        env:
+          DATABASE_URL: postgresql://app:password@localhost:5432/app_test?serverVersion=16
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies and run migrations
- tweak `.env.test` for CI database

## Testing
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_684031cdef8c832dab9428fb1b50244d